### PR TITLE
fix: replace workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [Yazi](https://github.com/sxyazi/yazi) plugin for bidirectional skipping of directories which only have a single subdirectory
 
-> [!NOTE]
-> This might be a little inconsistent for now as I'm currently using a (lazy) workaround to `Yazi`, for the time being, not having a way to tell if a directory is loaded. This will be fixed with `Yazi v0.2.6`.
-
 <https://github.com/Rolv-Apneseth/bypass.yazi/assets/69486699/5487537b-fe01-40e9-bc34-4d1116b491b5>
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -6,19 +6,20 @@
 
 ## Requirements
 
-- [Yazi](https://github.com/sxyazi/yazi) v0.2.4+
+- [Yazi](https://github.com/sxyazi/yazi) v0.3.3+
 
 ## Installation
 
-### Linux / MacOS
-
-```sh
-git clone https://github.com/Rolv-Apneseth/bypass.yazi.git ~/.config/yazi/plugins/bypass.yazi
+```bash
+ya pack -a Rolv-Apneseth/bypass
 ```
 
-### Windows
+### Manual
 
 ```sh
+# Linux / MacOS
+git clone https://github.com/Rolv-Apneseth/bypass.yazi.git ~/.config/yazi/plugins/bypass.yazi
+# Windows
 git clone https://github.com/Rolv-Apneseth/bypass.yazi.git %AppData%\yazi\config\plugins\bypass.yazi
 ```
 

--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,12 @@
 --[[     ya.notify({ title = "Bypass", content = message, timeout = 5 }) ]]
 --[[ end ]]
 
+---Returns the loading state of the current directory
+---@type fun(): boolean
+local is_directory_loaded = ya.sync(function(_)
+    return cx.active.current.stage.is_loading
+end)
+
 ---Enter hovered item if it is a directory
 ---@type fun(use_smart_enter: boolean): boolean
 local initial = ya.sync(function(_, use_smart_enter)
@@ -74,9 +80,10 @@ return {
         local run = is_reverse and initial_rev() or initial(use_smart_enter)
 
         while run do
-            -- TODO: avoid this workaround by using a "load" type hook once
-            -- Workaround: allow time for `current.files` to be defined
-            ya.sleep(0.01)
+            -- Wait for directory to have loaded
+            while is_directory_loaded() do
+                ya.sleep(0.002)
+            end
 
             -- Conditional enter/smart-enter/leave
             run = is_reverse and bypass_rev() or bypass()


### PR DESCRIPTION
Using the new `is_loading` state for the current directory, the previous workaround can be avoided. Still sleeping to prevent too many queries to the state though.