### PR TITLE
use_smart-enter -> use_smart_enter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Rolv Apneseth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# bypass.yazi
+
+[Yazi](https://github.com/sxyazi/yazi) plugin for bidirectional skipping of directories which only have a single subdirectory
+
+<https://github.com/Rolv-Apneseth/bypass.yazi/assets/69486699/5487537b-fe01-40e9-bc34-4d1116b491b5>
+
+## Requirements
+
+- [Yazi](https://github.com/sxyazi/yazi) v25.3.2+
+
+## Installation
+
+```bash
+ya pack -a Rolv-Apneseth/bypass
+```
+
+### Manual
+
+```sh
+# Linux / MacOS
+git clone https://github.com/Rolv-Apneseth/bypass.yazi.git ~/.config/yazi/plugins/bypass.yazi
+# Windows
+git clone https://github.com/Rolv-Apneseth/bypass.yazi.git %AppData%\yazi\config\plugins\bypass.yazi
+```
+
+## Usage
+
+Add this to your `keymap.toml`:
+
+```toml
+[[manager.prepend_keymap]]
+on = [ "L" ]
+run = "plugin bypass"
+desc = "Recursively enter child directory, skipping children with only a single subdirectory"
+[[manager.prepend_keymap]]
+on = [ "H" ]
+run = "plugin bypass reverse"
+desc = "Recursively enter parent directory, skipping parents with only a single subdirectory"
+```
+
+And that's it. You can bind any key you like, including overriding the default `enter` and `leave` bindings by setting them to `l` and `h` respectively.
+
+Note that  if you're using the [smart enter tip](https://yazi-rs.github.io/docs/tips#smart-enter) from the documentation, this plugin can replace that entirely by using this keybind instead:
+
+```toml
+[[manager.prepend_keymap]]
+on = [ "l" ]
+run = "plugin bypass smart-enter"
+desc = "Open a file, or recursively enter child directory, skipping children with only a single subdirectory"
+```

--- a/main.lua
+++ b/main.lua
@@ -1,0 +1,103 @@
+--- @since 25.3.2
+
+-- For development
+--[[ local function notify(message) ]]
+--[[     ya.notify({ title = "Bypass", content = message, timeout = 5 }) ]]
+--[[ end ]]
+
+---Returns the loading state of the current directory
+---@type fun(): boolean
+local is_directory_loading = ya.sync(function(_)
+    -- Try to use the v25.4.8 interface
+    local ok, res = pcall(cx.active.current.stage)
+    if ok then
+        return not res
+    -- Fallback to the v25.3.2 interface
+    else
+        return cx.active.current.stage.is_loading
+    end
+end)
+
+---Enter hovered item if it is a directory
+---@type fun(use_smart-enter: boolean): boolean
+local initial = ya.sync(function(_, use_smart-enter)
+    local hovered = cx.active.current.hovered
+    if hovered == nil then
+        return false
+    end
+
+    if not hovered.cha.is_dir then
+        -- Open file if using "smart enter"
+        if use_smart-enter then
+            ya.manager_emit("escape", { visual = true, select = true })
+            ya.manager_emit("open", { hovered = true })
+        end
+        return false
+    end
+
+    ya.manager_emit("escape", { visual = true, select = true })
+    ya.manager_emit("enter", { hovered = true })
+
+    return true
+end)
+
+---Enter hovered item if it is a directory and is the only item in the parent
+---@type fun(): boolean
+local bypass = ya.sync(function(_)
+    local hovered = cx.active.current.hovered
+
+    if hovered == nil or not hovered.cha.is_dir or #cx.active.current.files > 1 then
+        return false
+    end
+
+    ya.manager_emit("enter", { hovered = true })
+
+    return true
+end)
+
+---Leave the CWD, if the CWD has a parent
+---@type fun(): boolean
+local initial_rev = ya.sync(function(_)
+    if cx.active.parent == nil then
+        return false
+    end
+
+    ya.manager_emit("escape", { visual = true, select = true })
+    ya.manager_emit("leave", {})
+
+    return true
+end)
+
+---Leave the CWD, if the CWD has a parent and contains only one item
+---@type fun(): boolean
+local bypass_rev = ya.sync(function(_)
+    if cx.active.parent == nil or #cx.active.current.files > 1 then
+        return false
+    end
+
+    ya.manager_emit("leave", {})
+
+    return true
+end)
+
+return {
+    entry = function(_, job)
+        -- old version of Yazi will pass args directly, new version passes job. Below code ensures we derive args in both 0.3 and 0.4 Yazi API versions.
+        local args = job.args or job
+        local use_smart-enter = args and args[1] == "smart-enter"
+        local is_reverse = args and args[1] == "reverse"
+
+        -- Initial run, should behave like a regular enter/smart-enter/leave
+        local run = is_reverse and initial_rev() or initial(use_smart-enter)
+
+        while run do
+            -- Wait for directory to have loaded
+            while is_directory_loading() do
+                ya.sleep(0.002)
+            end
+
+            -- Conditional enter/smart-enter/leave
+            run = is_reverse and bypass_rev() or bypass()
+        end
+    end,
+}

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,10 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"
+
+[sort_requires]
+enabled = false


### PR DESCRIPTION
make it `smart-enter` same as yazi-plugins repo https://github.com/yazi-rs/plugins/tree/main/smart-enter.yazi